### PR TITLE
Reduce image size

### DIFF
--- a/hhvm-latest/Dockerfile
+++ b/hhvm-latest/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:14.04
 
-RUN apt-get update -y
-RUN apt-get install -y software-properties-common
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0x5a16e7281be7a449
-RUN add-apt-repository "deb http://dl.hhvm.com/ubuntu trusty main"
-RUN apt-get update -y && apt-get install -y hhvm=3.11.0~trusty
+RUN apt-get update -y && apt-get install -y software-properties-common \
+  && add-apt-repository "deb http://dl.hhvm.com/ubuntu trusty main" \
+  && apt-get update -y \
+  && apt-get install -y hhvm=3.11.0~trusty \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
According to Docker's [official best practice](https://docs.docker.com/engine/articles/dockerfile_best-practices/), I made few modifications to combine multiple commands and remove apt cache after hhvm installation.
- Before: 472.9MB
- After: 426.2MB - 10% smaller
