### PR TITLE
Fix branch names for releases

### DIFF
--- a/build-and-tag.sh
+++ b/build-and-tag.sh
@@ -29,7 +29,7 @@ else
   else
     HHVM_REPO_DISTRO="bionic-${MAJ_MIN}"
   fi
-  (git checkout "${MAJ_MIN}-lts" || git checkout "$MAJ_MIN" || true) 2>/dev/null
+  git checkout "origin/HHVM-$MAJ_MIN" 2>/dev/null
 fi
 
 docker build \


### PR DESCRIPTION
This never worked; on the build infra, things are OK because we ignore
failure and the EC2 user script checks out the correct branch.

Test Plan:

ran for 3.30.10 with:

```
diff --git a/build-and-tag.sh b/build-and-tag.sh
index a89f718..b4e8a89 100755
--- a/build-and-tag.sh
+++ b/build-and-tag.sh
@@ -29,22 +29,23 @@ else
   else
     HHVM_REPO_DISTRO="bionic-${MAJ_MIN}"
   fi
+  git stash
   git checkout "origin/HHVM-$MAJ_MIN" 2>/dev/null
 fi

-docker build \
-  --build-arg "HHVM_PACKAGE=$HHVM_PACKAGE" \
-  --build-arg "HHVM_REPO_DISTRO=$HHVM_REPO_DISTRO" \
-  -t "hhvm/hhvm:$VERSION" \
-  hhvm-latest/
-
-docker build \
-  --build-arg "HHVM_BASE_IMAGE=hhvm/hhvm:$VERSION" \
-  -t "hhvm/hhvm-proxygen:$VERSION" \
-  hhvm-latest-proxygen/
-
-docker push hhvm/hhvm:$VERSION
-docker push hhvm/hhvm-proxygen:$VERSION
+#docker build \
+#  --build-arg "HHVM_PACKAGE=$HHVM_PACKAGE" \
+#  --build-arg "HHVM_REPO_DISTRO=$HHVM_REPO_DISTRO" \
+#  -t "hhvm/hhvm:$VERSION" \
+#  hhvm-latest/
+#
+#docker build \
+#  --build-arg "HHVM_BASE_IMAGE=hhvm/hhvm:$VERSION" \
+#  -t "hhvm/hhvm-proxygen:$VERSION" \
+#  hhvm-latest-proxygen/
+#
+#docker push hhvm/hhvm:$VERSION
+#docker push hhvm/hhvm-proxygen:$VERSION

 for TAG in $(<EXTRA_TAGS); do
   docker tag "hhvm/hhvm:$VERSION" "hhvm/hhvm:$TAG"
```