### PR TITLE
fix build-and-tag.sh for 3.30 (#15)

### DIFF
--- a/build-and-tag.sh
+++ b/build-and-tag.sh
@@ -22,6 +22,12 @@ if echo "$VERSION" | $GREP -q '^\d{4}\.\d{2}\.\d{2}$'; then
 else
   HHVM_PACKAGE="hhvm=${VERSION}-*"
   MAJ_MIN=$(echo "$VERSION" | cut -f1,2 -d.)
+  if [ "${MAJ_MIN}" == "3.30" ]; then
+    # old repo naming scheme
+    HHVM_REPO_DISTRO="bionic-lts-${MAJ_MIN}"
+  else
+    HHVM_REPO_DISTRO="bionic-${MAJ_MIN}"
+  fi
   (git checkout "${MAJ_MIN}-lts" || git checkout "$MAJ_MIN" || true) 2>/dev/null
 fi
 


### PR DESCRIPTION
Needed; while this script doesn't check out the appropriate branch (yet - see #16), the AWS scripts do (https://github.com/hhvm/packaging/blob/c1e4060ebbf5435a4f427cf9f990158d429b8abd/aws/bin/update-docker#L34)